### PR TITLE
todo crud api추가

### DIFF
--- a/custom.d.ts
+++ b/custom.d.ts
@@ -1,0 +1,7 @@
+declare module '*.svg' {
+  import React = require('react');
+
+  export const ReactComponent: React.FC<React.SVGProps<SVGSVGElement>>;
+  const src: string;
+  export default src;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "jwt-decode": "^4.0.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-hot-toast": "^2.4.1",
         "react-router-dom": "^6.18.0",
         "react-scripts": "5.0.1",
         "styled-components": "^6.1.1",
@@ -8669,6 +8670,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/goober": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.13.tgz",
+      "integrity": "sha512-jFj3BQeleOoy7t93E9rZ2de+ScC4lQICLwiAQmKMg9F6roKGaLSHoCDYKkWlSafg138jejvq/mTdvmnwDQgqoQ==",
+      "peerDependencies": {
+        "csstype": "^3.0.10"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
@@ -14600,6 +14609,21 @@
       "version": "6.0.11",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
+    },
+    "node_modules/react-hot-toast": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.4.1.tgz",
+      "integrity": "sha512-j8z+cQbWIM5LY37pR6uZR6D4LfseplqnuAO4co4u8917hBUvXlEqyP1ZzqVLcqoyUesZZv/ImreoCeHVDpE5pQ==",
+      "dependencies": {
+        "goober": "^2.1.10"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
+      }
     },
     "node_modules/react-is": {
       "version": "17.0.2",
@@ -24049,6 +24073,12 @@
         "slash": "^3.0.0"
       }
     },
+    "goober": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.13.tgz",
+      "integrity": "sha512-jFj3BQeleOoy7t93E9rZ2de+ScC4lQICLwiAQmKMg9F6roKGaLSHoCDYKkWlSafg138jejvq/mTdvmnwDQgqoQ==",
+      "requires": {}
+    },
     "gopd": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
@@ -28151,6 +28181,14 @@
       "version": "6.0.11",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
+    },
+    "react-hot-toast": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.4.1.tgz",
+      "integrity": "sha512-j8z+cQbWIM5LY37pR6uZR6D4LfseplqnuAO4co4u8917hBUvXlEqyP1ZzqVLcqoyUesZZv/ImreoCeHVDpE5pQ==",
+      "requires": {
+        "goober": "^2.1.10"
+      }
     },
     "react-is": {
       "version": "17.0.2",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "jwt-decode": "^4.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-hot-toast": "^2.4.1",
     "react-router-dom": "^6.18.0",
     "react-scripts": "5.0.1",
     "styled-components": "^6.1.1",

--- a/src/api/axiosPublic.ts
+++ b/src/api/axiosPublic.ts
@@ -1,4 +1,4 @@
-import { JoinPropsType, LoginPropsType } from '../type/type';
+import { JoinPropsType, LoginPropsType } from '../type/user';
 import { axiosInstance } from './instance';
 import { instance } from './interceptors';
 

--- a/src/api/todo.ts
+++ b/src/api/todo.ts
@@ -1,0 +1,58 @@
+import { AddTodoPropsType, EditTodoPropsType } from '../type/todo';
+import { instance } from './interceptors';
+
+export const getTodosApi = async (id: number) => {
+  try {
+    const res = await instance.get(`/api/todos/${id}`);
+    return res.data;
+  } catch (error: any) {
+    throw new Error(error?.response?.data?.message || error);
+  }
+};
+
+export const addTodoApi = async (params: AddTodoPropsType) => {
+  try {
+    const res = await instance.post('/api/todos/create', {
+      title: params.title,
+      user_Id: params.userId,
+      contentId: params.contentId,
+      success: params.success,
+    });
+    return res.data;
+  } catch (error: any) {
+    throw new Error(error?.response?.data?.message || error);
+  }
+};
+
+export const editTodoApi = async (params: EditTodoPropsType) => {
+  try {
+    const res = await instance.patch('/api/todos/update', {
+      id: params.id,
+      title: params.title,
+      contentId: params.contentId,
+      success: params.success,
+    });
+    return res.data;
+  } catch (error: any) {
+    throw new Error(error?.response?.data?.message || error);
+  }
+};
+
+export const deleteTodoApi = async (id: number) => {
+  try {
+    const res = await instance.delete(`api/todos/delete/${id}`);
+    return res.data;
+  } catch (error: any) {
+    throw new Error(error?.response?.data?.message || error);
+  }
+};
+
+//content 가져오기
+// export const getContentsApi = async (id: number) => {
+//   try {
+//     const res = await instance.delete(`api/todos/delete/${id}`);
+//     return res.data;
+//   } catch (error: any) {
+//     throw new Error(error?.response?.data?.message || error);
+//   }
+// };

--- a/src/assets/icon/arrow.svg
+++ b/src/assets/icon/arrow.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 -960 960 960" width="24"><path d="M480-345 240-585l56-56 184 184 184-184 56 56-240 240Z"/></svg>

--- a/src/assets/icon/index.ts
+++ b/src/assets/icon/index.ts
@@ -1,0 +1,1 @@
+export { ReactComponent as ArrowIcon } from './arrow.svg';

--- a/src/components/atoms/Button.tsx
+++ b/src/components/atoms/Button.tsx
@@ -28,7 +28,7 @@ type Props = {
   buttonType?: 'button' | 'submit' | 'reset';
   buttonStyle?: string;
   isLoading?: boolean;
-  children: string | JSX.Element | JSX.Element[];
+  children: string | JSX.Element | JSX.Element[] | React.ReactNode;
   onClick?: () => void;
 };
 

--- a/src/components/atoms/Dropdown.tsx
+++ b/src/components/atoms/Dropdown.tsx
@@ -1,0 +1,86 @@
+import { useState, Dispatch, SetStateAction } from 'react';
+import styled from 'styled-components';
+import Button from './Button';
+import { ArrowIcon } from '../../assets/icon';
+import { TodoContentsIdType } from '../../type/todo';
+
+const DropdownWrap = styled.div`
+  width: 100%;
+  position: relative;
+`;
+
+const DropdownButton = styled(Button)`
+  width: 100px;
+  height: 40px;
+  background-color: #fff;
+  border-bottom: 1px solid #ddd;
+  border-radius: 0;
+  color: #000;
+`;
+
+const StyleArrowIcon = styled(ArrowIcon)`
+  vertical-align: middle;
+`;
+
+const DropdownUl = styled.ul`
+  position: absolute;
+  width: 100%;
+  background-color: #fff;
+  li {
+    &:hover {
+      button {
+        border-radius: 0;
+        background-color: #f0f0f0;
+      }
+    }
+  }
+`;
+
+type Props<T> = {
+  className?: string;
+  data: TodoContentsIdType<T>[];
+  titleId: number;
+  setTitleIdChange: Dispatch<SetStateAction<number>>;
+};
+
+const Dropdown = <T extends React.ReactNode>({
+  className,
+  data,
+  titleId,
+  setTitleIdChange,
+}: Props<T>) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const findTitle = data?.find((item: TodoContentsIdType<T>) => item.id === titleId);
+
+  const clickTitleDropdown = () => {
+    setIsOpen((prev) => !prev);
+  };
+
+  const clickDropdown = (id: number) => {
+    setTitleIdChange(id);
+    setIsOpen(false);
+  };
+
+  return (
+    <DropdownWrap className={className}>
+      <DropdownButton className="titleDropdownButton" onClick={clickTitleDropdown}>
+        {findTitle?.title}
+        <StyleArrowIcon />
+      </DropdownButton>
+
+      {isOpen && (
+        <DropdownUl>
+          {data.map((item: TodoContentsIdType<T>) => {
+            return (
+              <li key={item.id}>
+                <DropdownButton onClick={() => clickDropdown(item.id)}>{item.title}</DropdownButton>
+              </li>
+            );
+          })}
+        </DropdownUl>
+      )}
+    </DropdownWrap>
+  );
+};
+
+export default Dropdown;

--- a/src/components/molecules/AddTodoGroup.tsx
+++ b/src/components/molecules/AddTodoGroup.tsx
@@ -6,7 +6,7 @@ import Dropdown from '../atoms/Dropdown';
 import Input from '../atoms/Input';
 import Button from '../atoms/Button';
 import { JwtUserInfoType } from '../../type/user';
-import { contents } from '../../utils';
+import { contents } from '../../utils/common';
 import { flexbox } from '../../styles/flexbox';
 
 const AddTodoGroupWrap = styled.div`

--- a/src/components/molecules/AddTodoGroup.tsx
+++ b/src/components/molecules/AddTodoGroup.tsx
@@ -1,0 +1,87 @@
+import { useState, ChangeEvent } from 'react';
+import toast from 'react-hot-toast';
+import styled from 'styled-components';
+import { addTodoApi } from '../../api/todo';
+import Dropdown from '../atoms/Dropdown';
+import Input from '../atoms/Input';
+import Button from '../atoms/Button';
+import { JwtUserInfoType } from '../../type/user';
+import { contents } from '../../utils';
+import { flexbox } from '../../styles/flexbox';
+
+const AddTodoGroupWrap = styled.div`
+  ${flexbox('center', 'center')}
+  width: 100%;
+`;
+
+const TodoDropdown = styled(Dropdown)`
+  width: 100px;
+  .titleButton {
+    color: #000;
+    font-size: 16px;
+  }
+  ul {
+    li {
+      button {
+        color: #000;
+        height: 40px;
+      }
+    }
+  }
+`;
+
+const StyleInput = styled(Input)`
+  width: 100%;
+  border-bottom: 1px solid #000;
+  margin-left: 10px;
+  color: #000;
+`;
+
+const AddTodoButton = styled(Button)`
+  margin-left: 10px;
+  width: 100px;
+`;
+
+type Props = {
+  userInfo: JwtUserInfoType;
+  getTodos: () => void;
+};
+const AddTodoGroup = ({ userInfo, getTodos }: Props) => {
+  const [todoInputValue, setTodoInputValue] = useState('');
+  const [contentId, setContentId] = useState(contents[0].id);
+
+  const changeNewTitle = (e: ChangeEvent<HTMLInputElement>) => {
+    setTodoInputValue(e.currentTarget.value);
+  };
+
+  const addTodo = async () => {
+    if (todoInputValue.trim() === '') return alert('값을 입력해주세요');
+
+    try {
+      const res = await addTodoApi({
+        title: todoInputValue,
+        userId: userInfo.id,
+        contentId: contentId,
+        success: 0,
+      });
+      toast.success(res?.message);
+      getTodos();
+    } catch (error: any) {
+      toast.error(error.message);
+    } finally {
+      setTodoInputValue('');
+    }
+  };
+
+  return (
+    <AddTodoGroupWrap>
+      <TodoDropdown data={contents} titleId={contentId} setTitleIdChange={setContentId} />
+      <StyleInput value={todoInputValue} onChange={changeNewTitle} />
+      <AddTodoButton className="success" onClick={addTodo}>
+        추가
+      </AddTodoButton>
+    </AddTodoGroupWrap>
+  );
+};
+
+export default AddTodoGroup;

--- a/src/components/molecules/EditTodoItem.tsx
+++ b/src/components/molecules/EditTodoItem.tsx
@@ -1,0 +1,84 @@
+import { ChangeEvent, Dispatch, SetStateAction } from 'react';
+import styled from 'styled-components';
+import Dropdown from '../atoms/Dropdown';
+import Input from '../atoms/Input';
+import { EditContentsType } from '../../type/todo';
+import { contents } from '../../utils';
+import { flexbox } from '../../styles/flexbox';
+
+const EditTotoItem = styled.div`
+  width: calc(100% - 30% - 20px);
+  ${flexbox('flex-start', 'center')}
+`;
+
+const EditCheckBox = styled.input`
+  margin-right: 10px;
+  width: 30px;
+  height: 20px;
+  background-color: #fff;
+  &:checked {
+    background-color: blue;
+  }
+`;
+
+const TodoDropdown = styled(Dropdown)`
+  width: 100px;
+  .titleButton {
+    color: #000;
+    font-size: 16px;
+  }
+  ul {
+    li {
+      button {
+        color: #000;
+        height: 40px;
+      }
+    }
+  }
+`;
+
+const StyleInput = styled(Input)`
+  width: 100%;
+  border-bottom: 1px solid #000;
+  margin-left: 10px;
+  color: #000;
+`;
+
+type Props = {
+  editContents: EditContentsType;
+  setEditContents: Dispatch<SetStateAction<EditContentsType>>;
+  editContentId: number;
+  setEditContentId: Dispatch<SetStateAction<number>>;
+};
+
+const EditTodoItem = ({
+  editContents,
+  setEditContents,
+  editContentId,
+  setEditContentId,
+}: Props) => {
+  const changeEditTitle = (e: ChangeEvent<HTMLInputElement>) => {
+    const { value } = e.currentTarget;
+    setEditContents((prev: EditContentsType) => {
+      return { ...prev, title: value };
+    });
+  };
+
+  const changeSuccess = () => {
+    setEditContents((prev: EditContentsType) => ({ ...prev, success: prev.success === 0 ? 1 : 0 }));
+  };
+
+  return (
+    <EditTotoItem>
+      <EditCheckBox
+        type="checkbox"
+        onChange={changeSuccess}
+        checked={editContents.success === 0 ? false : true}
+      />
+      <TodoDropdown data={contents} titleId={editContentId} setTitleIdChange={setEditContentId} />
+      <StyleInput value={editContents.title} onChange={changeEditTitle} />
+    </EditTotoItem>
+  );
+};
+
+export default EditTodoItem;

--- a/src/components/molecules/EditTodoItem.tsx
+++ b/src/components/molecules/EditTodoItem.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import Dropdown from '../atoms/Dropdown';
 import Input from '../atoms/Input';
 import { EditContentsType } from '../../type/todo';
-import { contents } from '../../utils';
+import { contents } from '../../utils/common';
 import { flexbox } from '../../styles/flexbox';
 
 const EditTotoItem = styled.div`

--- a/src/components/molecules/TodoEditAndDeleteButtons.tsx
+++ b/src/components/molecules/TodoEditAndDeleteButtons.tsx
@@ -1,0 +1,115 @@
+import { Dispatch, SetStateAction } from 'react';
+import toast from 'react-hot-toast';
+import styled from 'styled-components';
+import { deleteTodoApi, editTodoApi } from '../../api/todo';
+import Button from '../atoms/Button';
+import { userState } from '../../store/login';
+import { EditTodoPropsType } from '../../type/todo';
+import { EditContentsType, TodosType } from '../../type/todo';
+import { flexbox } from '../../styles/flexbox';
+
+const ButtonWrap = styled.div`
+  ${flexbox('flex-end', 'center')}
+  width: 30%;
+  margin-left: 10px;
+
+  button {
+    &:last-child {
+      margin-left: 10px;
+    }
+  }
+`;
+
+const TodoButton = styled(Button)`
+  width: 80px;
+  background-color: #e59a38;
+`;
+
+type Props = {
+  todos: TodosType[];
+  todo: TodosType;
+  editId: number;
+  setEditId: Dispatch<SetStateAction<number>>;
+  editContents: EditContentsType;
+  setEditContents: Dispatch<SetStateAction<EditContentsType>>;
+  editContentId: number;
+  setEditContentId: Dispatch<SetStateAction<number>>;
+  getTodos: () => void;
+};
+
+const TodoEditAndDeleteButtons = ({
+  todos,
+  todo,
+  editId,
+  setEditId,
+  editContents,
+  setEditContents,
+  editContentId,
+  setEditContentId,
+  getTodos,
+}: Props) => {
+  const { userInfo } = userState();
+
+  const isEdit = (item: EditTodoPropsType) => {
+    setEditId(item.id);
+    setEditContentId(item.contentId);
+    setEditContents({
+      title: item.title,
+      id: userInfo?.id,
+      success: item.success,
+    });
+  };
+
+  const editTodo = async (item: EditTodoPropsType) => {
+    const findTodo = todos.find((i: TodosType) => i.id === item.id);
+    if (!findTodo) {
+      toast.error('수정 실패했습니다');
+      return;
+    }
+
+    const { title, contentId, success } = findTodo;
+    if (title !== item.title || contentId !== item.contentId || success !== item.success) {
+      try {
+        const res = await editTodoApi(item);
+        toast.success(res?.message);
+        getTodos();
+      } catch (error: any) {
+        toast.success(error.message);
+      }
+    } else {
+      setEditId(0);
+    }
+  };
+
+  const deleteTodo = async (id: number) => {
+    try {
+      const res = await deleteTodoApi(id);
+      toast.success(res?.message);
+      getTodos();
+    } catch (error: any) {
+      toast.error(error.message);
+    }
+  };
+
+  return (
+    <ButtonWrap>
+      {editId === todo.id ? (
+        <TodoButton
+          onClick={() =>
+            editTodo({
+              title: editContents.title,
+              id: todo.id,
+              contentId: editContentId,
+              success: editContents.success,
+            })
+          }>
+          수정완료
+        </TodoButton>
+      ) : (
+        <TodoButton onClick={() => isEdit(todo)}>수정</TodoButton>
+      )}
+      <TodoButton onClick={() => deleteTodo(todo.id)}>삭제</TodoButton>
+    </ButtonWrap>
+  );
+};
+export default TodoEditAndDeleteButtons;

--- a/src/components/molecules/TodoListItem.tsx
+++ b/src/components/molecules/TodoListItem.tsx
@@ -1,0 +1,39 @@
+import styled from 'styled-components';
+import { flexbox } from '../../styles/flexbox';
+import { contents } from '../../utils';
+import { TodosType } from '../../type/todo';
+
+const StyleTodoListItem = styled.div`
+  width: calc(100% - 30% - 20px);
+  ${flexbox('flex-start', 'center')}
+`;
+
+const TodoDropdownTitle = styled.span`
+  width: 100px;
+  background-color: #fff;
+  padding: 10px;
+  display: block;
+`;
+
+const TodoTitle = styled.p<{ $success: boolean }>`
+  margin-left: 10px;
+  text-decoration: ${({ $success }) => ($success ? `line-through` : 'none')};
+`;
+
+type Props = {
+  todo: TodosType;
+};
+
+const TodoListItem = ({ todo }: Props) => {
+  return (
+    <StyleTodoListItem>
+      <TodoDropdownTitle>
+        {contents.map((item) => {
+          return item.id === todo.contentId && item.title;
+        })}
+      </TodoDropdownTitle>
+      <TodoTitle $success={todo.success === 0 ? false : true}>{todo.title}</TodoTitle>
+    </StyleTodoListItem>
+  );
+};
+export default TodoListItem;

--- a/src/components/molecules/TodoListItem.tsx
+++ b/src/components/molecules/TodoListItem.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 import { flexbox } from '../../styles/flexbox';
-import { contents } from '../../utils';
+import { contents } from '../../utils/common';
 import { TodosType } from '../../type/todo';
 
 const StyleTodoListItem = styled.div`

--- a/src/components/organisms/Header.tsx
+++ b/src/components/organisms/Header.tsx
@@ -1,11 +1,9 @@
+import { useEffect } from 'react';
 import { Link, NavLink, useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import { userState } from '../../store/login';
-import { useEffect } from 'react';
-import { jwtDecode } from 'jwt-decode';
 import Button from '../atoms/Button';
-import { getLocalStorageToken } from '../../utils';
-import { JwtUserInfoType } from '../../type/user';
+import { getUserInfoJwtDecode } from '../../utils';
 
 const StyledHeader = styled.header`
   width: 100%;
@@ -48,9 +46,8 @@ const Header = () => {
   const navigate = useNavigate();
 
   useEffect(() => {
-    const token = getLocalStorageToken();
-    if (token) {
-      const user: JwtUserInfoType = jwtDecode(token?.accessToken);
+    const user = getUserInfoJwtDecode();
+    if (user) {
       setUserInfo(user);
     }
   }, [setUserInfo]);
@@ -59,7 +56,7 @@ const Header = () => {
     localStorage.removeItem('token');
     setUserInfo({ id: 0, alias: '', email: '', exp: 0, iat: 0 });
     alert('로그아웃 되었습니다');
-    navigate('/');
+    navigate('/login');
   };
 
   return (

--- a/src/components/organisms/Header.tsx
+++ b/src/components/organisms/Header.tsx
@@ -5,7 +5,7 @@ import { useEffect } from 'react';
 import { jwtDecode } from 'jwt-decode';
 import Button from '../atoms/Button';
 import { getLocalStorageToken } from '../../utils';
-import { UserType } from '../../type/type';
+import { JwtUserInfoType } from '../../type/user';
 
 const StyledHeader = styled.header`
   width: 100%;
@@ -50,14 +50,14 @@ const Header = () => {
   useEffect(() => {
     const token = getLocalStorageToken();
     if (token) {
-      const user: UserType = jwtDecode(token?.accessToken);
+      const user: JwtUserInfoType = jwtDecode(token?.accessToken);
       setUserInfo(user);
     }
   }, [setUserInfo]);
 
   const logoutHandler = () => {
     localStorage.removeItem('token');
-    setUserInfo({ id: 0, userId: '', email: '', exp: 0, iat: 0 });
+    setUserInfo({ id: 0, alias: '', email: '', exp: 0, iat: 0 });
     alert('로그아웃 되었습니다');
     navigate('/');
   };
@@ -68,9 +68,9 @@ const Header = () => {
         <Link to="/">TODO</Link>
       </h1>
       <Nav>
-        {userInfo?.userId ? (
+        {userInfo?.alias ? (
           <>
-            <li>{`${userInfo.userId}님 안녕하세요`}</li>
+            <li>{`${userInfo.alias}님 안녕하세요`}</li>
             <li>
               <Button onClick={logoutHandler}>Logout</Button>
             </li>

--- a/src/components/organisms/JoinForm.tsx
+++ b/src/components/organisms/JoinForm.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import InputGroup from '../molecules/InputGroup';
 import ErrorMessage from '../atoms/ErrorMessage';
 import Button from '../atoms/Button';
-import { JoinErrorMessageType, JoinType } from '../../type/type';
+import { JoinErrorMessageType, JoinType } from '../../type/user';
 
 const JoinErrorMessage = styled(ErrorMessage)`
   margin-bottom: 20px;

--- a/src/components/organisms/TodoListGroup.tsx
+++ b/src/components/organisms/TodoListGroup.tsx
@@ -1,0 +1,71 @@
+import { useState, Dispatch, SetStateAction } from 'react';
+import styled from 'styled-components';
+import EditTodoItem from '../molecules/EditTodoItem';
+import TodoListItem from '../molecules/TodoListItem';
+import TodoEditAndDeleteButtons from '../molecules/TodoEditAndDeleteButtons';
+import { TodosType } from '../../type/todo';
+import { contents } from '../../utils';
+import { flexbox } from '../../styles/flexbox';
+
+const TodoGroupWrap = styled.ul`
+  margin-bottom: 30px;
+  width: 100%;
+  max-height: 350px;
+  overflow-y: auto;
+
+  > li {
+    width: 100%;
+    margin-bottom: 10px;
+    ${flexbox('space-between', 'center')}
+  }
+`;
+
+type Props = {
+  getTodos: () => void;
+  todos: TodosType[];
+  editId: number;
+  setEditId: Dispatch<SetStateAction<number>>;
+};
+
+const TodoListGroup = ({ getTodos, todos, editId, setEditId }: Props) => {
+  const [editContentId, setEditContentId] = useState(contents[0].id);
+  const [editContents, setEditContents] = useState({
+    title: '',
+    id: 0,
+    success: 0,
+  });
+
+  return (
+    <TodoGroupWrap>
+      {todos.map((item: TodosType) => {
+        return (
+          <li key={item.id}>
+            {editId === item.id ? (
+              <EditTodoItem
+                editContents={editContents}
+                setEditContents={setEditContents}
+                editContentId={editContentId}
+                setEditContentId={setEditContentId}
+              />
+            ) : (
+              <TodoListItem todo={item} />
+            )}
+
+            <TodoEditAndDeleteButtons
+              todos={todos}
+              todo={item}
+              editId={editId}
+              setEditId={setEditId}
+              editContents={editContents}
+              setEditContents={setEditContents}
+              editContentId={editContentId}
+              setEditContentId={setEditContentId}
+              getTodos={getTodos}
+            />
+          </li>
+        );
+      })}
+    </TodoGroupWrap>
+  );
+};
+export default TodoListGroup;

--- a/src/components/organisms/TodoListGroup.tsx
+++ b/src/components/organisms/TodoListGroup.tsx
@@ -4,7 +4,7 @@ import EditTodoItem from '../molecules/EditTodoItem';
 import TodoListItem from '../molecules/TodoListItem';
 import TodoEditAndDeleteButtons from '../molecules/TodoEditAndDeleteButtons';
 import { TodosType } from '../../type/todo';
-import { contents } from '../../utils';
+import { contents } from '../../utils/common';
 import { flexbox } from '../../styles/flexbox';
 
 const TodoGroupWrap = styled.ul`

--- a/src/pages/join/Join.tsx
+++ b/src/pages/join/Join.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
-import { JoinType, JoinErrorMessageType } from '../../type/type';
+import { JoinType, JoinErrorMessageType } from '../../type/user';
 import { joinApi } from '../../api/axiosPublic';
 import JoinForm from '../../components/organisms/JoinForm';
 import { isValidate } from '../../utils';

--- a/src/pages/login/Login.tsx
+++ b/src/pages/login/Login.tsx
@@ -2,12 +2,12 @@ import { useState, ChangeEvent, FormEvent } from 'react';
 import styled from 'styled-components';
 import InputGroup from '../../components/molecules/InputGroup';
 import Button from '../../components/atoms/Button';
-import { LoginType, JwtUserInfoType } from '../../type/user';
+import { LoginType } from '../../type/user';
 import { loginApi } from '../../api/axiosPublic';
 import { useNavigate } from 'react-router-dom';
-import { jwtDecode } from 'jwt-decode';
 import { userState } from '../../store/login';
 import ErrorMessage from '../../components/atoms/ErrorMessage';
+import { getUserInfoJwtDecode } from '../../utils';
 
 const LoginWrap = styled.section`
   width: 100%;
@@ -56,13 +56,13 @@ const Login = () => {
     try {
       setIsLoading(true);
       const res = await loginApi({ alias: loginValue.id, password: loginValue.password });
-      if (res) {
-        localStorage.setItem('token', JSON.stringify(res.token));
-        const user: JwtUserInfoType = jwtDecode(res.token.accessToken);
+      localStorage.setItem('token', JSON.stringify(res?.token));
+      const user = getUserInfoJwtDecode();
+      if (user) {
         setUserInfo(user);
-        alert('로그인 되었습니다.');
-        navigate('/');
       }
+      alert('로그인 되었습니다.');
+      navigate('/');
     } catch (error: any) {
       setErrorMessage((prev) => ({ ...prev, error: error.message }));
     } finally {

--- a/src/pages/login/Login.tsx
+++ b/src/pages/login/Login.tsx
@@ -2,7 +2,7 @@ import { useState, ChangeEvent, FormEvent } from 'react';
 import styled from 'styled-components';
 import InputGroup from '../../components/molecules/InputGroup';
 import Button from '../../components/atoms/Button';
-import { LoginType, UserType } from '../../type/type';
+import { LoginType, JwtUserInfoType } from '../../type/user';
 import { loginApi } from '../../api/axiosPublic';
 import { useNavigate } from 'react-router-dom';
 import { jwtDecode } from 'jwt-decode';
@@ -58,7 +58,7 @@ const Login = () => {
       const res = await loginApi({ alias: loginValue.id, password: loginValue.password });
       if (res) {
         localStorage.setItem('token', JSON.stringify(res.token));
-        const user: UserType = jwtDecode(res.token.accessToken);
+        const user: JwtUserInfoType = jwtDecode(res.token.accessToken);
         setUserInfo(user);
         alert('로그인 되었습니다.');
         navigate('/');

--- a/src/pages/todo/Todo.tsx
+++ b/src/pages/todo/Todo.tsx
@@ -1,9 +1,11 @@
-import { ChangeEvent, useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
+import toast, { Toaster } from 'react-hot-toast';
 import styled from 'styled-components';
-import { Todos } from '../../type/type';
-import Button from '../../components/atoms/Button';
-import Input from '../../components/atoms/Input';
 import { testApi } from '../../api/axiosPublic';
+import { getTodosApi } from '../../api/todo';
+import { userState } from '../../store/login';
+import AddTodoGroup from '../../components/molecules/AddTodoGroup';
+import TodoListGroup from '../../components/organisms/TodoListGroup';
 
 const TodoWrap = styled.section`
   width: 100%;
@@ -13,8 +15,8 @@ const TodoWrap = styled.section`
   align-items: center;
 `;
 
-const TodoBox = styled.div`
-  width: 500px;
+const TodoContainer = styled.div`
+  width: 700px;
   background-color: #ddd;
   padding: 30px;
 
@@ -25,87 +27,23 @@ const TodoBox = styled.div`
   }
 `;
 
-const TodoList = styled.ul`
-  margin-bottom: 30px;
-  width: 100%;
-
-  li {
-    width: 100%;
-    margin-bottom: 10px;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    input {
-      width: 60%;
-    }
-  }
-`;
-
-const ButtonWrap = styled.div`
-  width: calc(100% - 60% - 10px);
-  margin-left: 10px;
-  text-align: right;
-
-  button {
-    &:last-child {
-      margin-left: 10px;
-    }
-  }
-`;
-
-const TodoInputWrap = styled.div`
-  width: 100%;
-  input {
-    width: 80%;
-  }
-  button {
-    margin-left: 10px;
-    width: calc(100% - 80% - 10px);
-  }
-`;
-
 function Todo() {
-  const [todoInputValue, setTodoInputValue] = useState('');
-  const [todos, setTodos] = useState<Todos[]>([]);
-  const [editInputValue, setEditInputValue] = useState('');
-
-  const addHandler = () => {
-    if (todoInputValue.trim() === '') return alert('값을 입력해주세요');
-
-    setTodos((prev) => [...prev, { id: Date.now(), title: todoInputValue, isEdit: false }]);
-    setTodoInputValue('');
-  };
-
-  const confirmHandler = (item: Todos) => {
-    setTodos((prev) =>
-      prev.map((i) =>
-        i.id === item.id ? { ...item, title: editInputValue, isEdit: false } : { ...i },
-      ),
-    );
-  };
-
-  const editHandler = (item: Todos) => {
-    setTodos((prev) =>
-      prev.map((i) => (i.id === item.id ? { ...item, isEdit: true } : { ...i, isEdit: false })),
-    );
-    setEditInputValue(item.title);
-  };
-
-  const deleteHandler = (id: number) => {
-    setTodos((prev) => prev.filter((item) => id !== item.id));
-  };
-
-  const changeTitle = (e: ChangeEvent<HTMLInputElement>) => {
-    const { value } = e.currentTarget;
-    setEditInputValue(value);
-  };
-
-  const onChangeHandler = (e: ChangeEvent<HTMLInputElement>) => {
-    setTodoInputValue(e.currentTarget.value);
-  };
+  const { userInfo } = userState();
+  const [todos, setTodos] = useState([]);
+  const [editId, setEditId] = useState(0);
 
   const [testData, setTestData] = useState('');
   const [testError, setTestError] = useState('');
+
+  const getTodos = async () => {
+    try {
+      const res = await getTodosApi(userInfo.id);
+      setTodos(res);
+      setEditId(0);
+    } catch (error: any) {
+      toast.error(error.message);
+    }
+  };
 
   const test = async () => {
     try {
@@ -120,40 +58,24 @@ function Todo() {
     test();
   }, []);
 
+  useEffect(() => {
+    if (userInfo.id !== 0) {
+      getTodos();
+    }
+  }, [userInfo]);
+
   return (
     <TodoWrap>
-      <TodoBox>
+      <TodoContainer>
         <h1>TODO</h1>
         <p>{testData ? testData : testError}</p>
 
-        <TodoList>
-          {todos.map((item: Todos) => {
-            return (
-              <li key={item.id}>
-                {item.isEdit ? (
-                  <input type="text" value={editInputValue} onChange={changeTitle} />
-                ) : (
-                  <p>{item.title}</p>
-                )}
-                <ButtonWrap>
-                  <Button onClick={() => (item.isEdit ? confirmHandler : editHandler)(item)}>
-                    {item.isEdit ? '수정완료' : '수정'}
-                  </Button>
-                  <Button onClick={() => deleteHandler(item.id)}>삭제</Button>
-                </ButtonWrap>
-              </li>
-            );
-          })}
-        </TodoList>
+        <TodoListGroup todos={todos} editId={editId} setEditId={setEditId} getTodos={getTodos} />
 
-        <TodoInputWrap>
-          <Input value={todoInputValue} onChange={onChangeHandler} />
-          <Button className="success" onClick={addHandler}>
-            추가
-          </Button>
-        </TodoInputWrap>
-        <table></table>
-      </TodoBox>
+        <AddTodoGroup userInfo={userInfo} getTodos={getTodos} />
+      </TodoContainer>
+
+      <Toaster position="top-center" reverseOrder={false} />
     </TodoWrap>
   );
 }

--- a/src/store/login.ts
+++ b/src/store/login.ts
@@ -1,12 +1,12 @@
 import { create } from 'zustand';
-import { UserType } from '../type/type';
+import { JwtUserInfoType } from '../type/user';
 
 type userInfoType = {
-  userInfo: UserType;
-  setUserInfo: (value: UserType) => void;
+  userInfo: JwtUserInfoType;
+  setUserInfo: (value: JwtUserInfoType) => void;
 };
 
 export const userState = create<userInfoType>((set) => ({
-  userInfo: { id: 0, userId: '', email: '', exp: 0, iat: 0 },
-  setUserInfo: (newValue: UserType) => set({ userInfo: newValue }),
+  userInfo: { id: 0, alias: '', email: '', exp: 0, iat: 0 },
+  setUserInfo: (newValue: JwtUserInfoType) => set({ userInfo: newValue }),
 }));

--- a/src/styles/flexbox.ts
+++ b/src/styles/flexbox.ts
@@ -1,0 +1,7 @@
+import { css } from 'styled-components';
+
+export const flexbox = (js = 'center', al: 'center') => css`
+  display: flex;
+  justify-content: ${js};
+  align-items: ${al};
+`;

--- a/src/type/todo.ts
+++ b/src/type/todo.ts
@@ -1,0 +1,23 @@
+import { UserType } from './user';
+
+export type TodosType = {
+  id: number;
+  title: string;
+  success: number;
+  contentId: number;
+  user_id: number;
+  user: UserType;
+};
+
+export type TodoContentsIdType<T> = { id: number; title: T };
+
+export type EditContentsType = { title: string; id: number; success: number };
+
+export type AddTodoPropsType = {
+  title: string;
+  userId: number;
+  contentId: number;
+  success: number;
+};
+
+export type EditTodoPropsType = { id: number; title: string; contentId: number; success: number };

--- a/src/type/user.ts
+++ b/src/type/user.ts
@@ -1,9 +1,4 @@
-export type Todos = {
-  id: number;
-  title: string;
-  isEdit: boolean;
-};
-
+//join
 export type JoinType = {
   id: string;
   password: string;
@@ -28,6 +23,7 @@ export type JoinErrorMessageType = {
   error: string;
 };
 
+//login
 export type LoginType = {
   id: string;
   password: string;
@@ -35,4 +31,17 @@ export type LoginType = {
 
 export type LoginPropsType = { alias: string; password: string };
 
-export type UserType = { id: number; userId: string; email: string; exp: number; iat: number };
+//user
+export type JwtUserInfoType = {
+  id: number;
+  alias: string;
+  email: string;
+  exp: number;
+  iat: number;
+};
+
+export type UserType = {
+  alias: string;
+  email: string;
+  name: string;
+};

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -1,0 +1,6 @@
+export const emailRegEx = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/;
+
+export const contents = [
+  { id: 1, title: '스터디' },
+  { id: 2, title: '할일' },
+];

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,5 @@
-import { JoinErrorMessageType, JoinType } from '../type/user';
+import { jwtDecode } from 'jwt-decode';
+import { JoinErrorMessageType, JoinType, JwtUserInfoType } from '../type/user';
 import { emailRegEx } from './common';
 
 export const isValidate = (value: JoinType, errorMessage: JoinErrorMessageType) => {
@@ -34,6 +35,15 @@ export const getLocalStorageToken = () => {
   if (token) {
     const { accessToken, refreshToken } = JSON.parse(token);
     return { accessToken, refreshToken };
+  }
+  return null;
+};
+
+export const getUserInfoJwtDecode = () => {
+  const token = getLocalStorageToken();
+  if (token) {
+    const user: JwtUserInfoType = jwtDecode(token?.accessToken);
+    return user;
   }
   return null;
 };

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,6 +1,5 @@
-import { JoinErrorMessageType, JoinType } from '../type/type';
-
-export const emailRegEx = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/;
+import { JoinErrorMessageType, JoinType } from '../type/user';
+import { emailRegEx } from './common';
 
 export const isValidate = (value: JoinType, errorMessage: JoinErrorMessageType) => {
   errorMessage.error = '';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -20,7 +16,5 @@
     "noEmit": true,
     "jsx": "react-jsx"
   },
-  "include": [
-    "src"
-  ]
+  "include": ["src", "custom.d.ts"]
 }


### PR DESCRIPTION
작업내용 🛠
- todo 페이지 crud api 추가
- todo 컴포넌트 분리
- dropdown컴포넌트 추가
- todo 타입파일 추가

체크 리스트 ✅
- 구현한 기능이 잘 동작하는지 직접 브라우저에서 확인/테스트 했습니다.
- 외부 의존성 라이브러리의 변경점이 있어서 npm install을 실행해야합니다
- 로그인 계정 : amy / 123123
- todo add : 드롭다운 선택, input 입력 -> 추가버튼
- todo edit : 수정 클릭 -> 드롭다운 변경가능, input 변경가능, success(완료, 미완료) 선택가능
- todo remove : 삭제버튼 클릭
  

스크린샷 🌠
N/A

참고사항 📖
N/A